### PR TITLE
command: make watch command bidirectional

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -521,6 +521,9 @@ def process_mavlink(slave):
         return
     if mpstate.settings.mavfwd and not mpstate.status.setup_mode:
         for m in msgs:
+            if mpstate.status.watch is not None:
+                if fnmatch.fnmatch(m.get_type().upper(), mpstate.status.watch.upper()):
+                    mpstate.console.writeln('> '+ str(m))
             mpstate.master().write(m.get_msgbuf())
     mpstate.status.counters['Slave'] += 1
 

--- a/MAVProxy/modules/mavproxy_link.py
+++ b/MAVProxy/modules/mavproxy_link.py
@@ -184,6 +184,10 @@ class LinkModule(mp_module.MPModule):
 
     def master_send_callback(self, m, master):
         '''called on sending a message'''
+        if self.status.watch is not None:
+            if fnmatch.fnmatch(m.get_type().upper(), self.status.watch.upper()):
+                self.mpstate.console.writeln('> '+ str(m))
+
         mtype = m.get_type()
         if mtype != 'BAD_DATA' and self.mpstate.logqueue:
             usec = self.get_usec()
@@ -393,7 +397,7 @@ class LinkModule(mp_module.MPModule):
 
         if self.status.watch is not None:
             if fnmatch.fnmatch(m.get_type().upper(), self.status.watch.upper()):
-                self.mpstate.console.writeln(m)
+                self.mpstate.console.writeln('< '+str(m))
 
         # don't pass along bad data
         if mtype != 'BAD_DATA':


### PR DESCRIPTION
So something like the prompt bellow is posssible
```
STABILIZE> watch *PARAM*
STABILIZE> Watching *PARAM*
STABILIZE> param set SYSID_THISMAV 1
>PARAM_SET {target_system : 1, target_component : 0, param_id : SYSID_THISMAV, param_value : 1.0, param_type : 9}
<PARAM_VALUE {param_id : SYSID_THISMAV, param_value : 1.0, param_type : 4, param_count : 487, param_index : 65535}
```