### PR TITLE
default to local udp host if there is no 'master' arg or hardware connected

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -901,6 +901,10 @@ if __name__ == '__main__':
     if not opts.master and len(serial_list) == 1:
           print("Connecting to %s" % serial_list[0])
           mpstate.module('link').link_add(serial_list[0].device)
+    elif not opts.master:
+          wifi_device = '0.0.0.0:14550'
+          mpstate.module('link').link_add(wifi_device)
+
 
     # log all packets from the master, for later replay
     open_logs()


### PR DESCRIPTION
This is useful if you have a 3DR Solo connected to your wifi network, and no serial ports connected.

I don't see any downsides.