### PR TITLE
mavproxy.py: return False from module load ImportError handler

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -273,7 +273,8 @@ def load_module(modname, quiet=False):
             if mpstate.settings.moddebug > 1:
                 import traceback
                 print(traceback.format_exc())
-    print("Failed to load module: %s. Use 'set moddebug 3' in the MAVProxy console to enable traceback" % ex)
+                print("Failed to load module: %s. Use 'set moddebug 2' in the MAVProxy console to enable traceback" % ex)
+                return False
     return False
 
 def unload_module(modname):


### PR DESCRIPTION
If you tried to import a module which had also had an import error
in it, the MAVProxy console became unusable.