### PR TITLE
Replaces "darkgreen" with "dark green" for WX

### DIFF
--- a/MAVProxy/modules/lib/live_graph.py
+++ b/MAVProxy/modules/lib/live_graph.py
@@ -23,7 +23,7 @@ class LiveGraph():
                  title='MAVProxy: LiveGraph',
                  timespan=20.0,
                  tickresolution=0.2,
-                 colors=[ 'red', 'green', 'blue', 'orange', 'olive', 'cyan', 'magenta', 'brown', 'darkgreen',
+                 colors=[ 'red', 'green', 'blue', 'orange', 'olive', 'cyan', 'magenta', 'brown', 'dark green',
                           'violet', 'purple', 'grey', 'black']):
         import multiprocessing
         self.fields = fields

--- a/MAVProxy/modules/mavproxy_console.py
+++ b/MAVProxy/modules/mavproxy_console.py
@@ -303,7 +303,7 @@ class ConsoleModule(mp_module.MPModule):
                     if linkdelay > 1:
                         fg = 'orange'
                     else:
-                        fg = 'darkgreen'
+                        fg = 'dark green'
                 self.console.set_status('Link%u'%m.linknum, linkline, row=1, fg=fg)
         elif type in ['WAYPOINT_CURRENT', 'MISSION_CURRENT']:
             self.console.set_status('WP', 'WP %u' % msg.seq)


### PR DESCRIPTION
WX requires the string "dark green" (two words), or it outputs this error:

```
09:37:22 AM: Debug: wxColour::Set - couldn't set to colour string 'darkgreen'
```