### PR TITLE
fix lat, lon of updated ADSB message for map module

### DIFF
--- a/MAVProxy/modules/mavproxy_map/__init__.py
+++ b/MAVProxy/modules/mavproxy_map/__init__.py
@@ -468,7 +468,7 @@ class MapModule(mp_module.MPModule):
             id = 'ADSB-' + str(m.ICAO_address)
             # use plane icon for now
             self.create_vehicle_icon(id, 'green', vehicle_type='plane')
-            self.mpstate.map.set_position(id, (m.lat, m.lon), rotation=m.heading)    
+            self.mpstate.map.set_position(id, (m.lat*1.0e-7, m.lon*1.0e-7), rotation=m.heading)    
             
         # if the waypoints have changed, redisplay
         last_wp_change = self.module('wp').wploader.last_change


### PR DESCRIPTION
Display of simulated ADSB enabled aircraft was broken with mavlink/mavlink@7df9c75a19eab6292b580f3d26c07f6f8f92c196
This pull request fixes that issue.