### PR TITLE
link: change prompt immediately on mode change

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -50,6 +50,7 @@ class MPStatus(object):
         self.exit = False
         self.flightmode = 'MAV'
         self.last_mode_announce = 0
+        self.last_mode_announced = 'MAV'
         self.logdir = None
         self.last_heartbeat = 0
         self.last_message = 0

--- a/MAVProxy/modules/mavproxy_link.py
+++ b/MAVProxy/modules/mavproxy_link.py
@@ -311,12 +311,15 @@ class LinkModule(mp_module.MPModule):
                 else:
                     self.say("DISARMED")
 
-            if master.flightmode != self.status.flightmode and time.time() > self.status.last_mode_announce + 2:
+            if master.flightmode != self.status.flightmode:
                 self.status.flightmode = master.flightmode
-                self.status.last_mode_announce = time.time()
                 if self.mpstate.functions.input_handler is None:
                     self.mpstate.rl.set_prompt(self.status.flightmode + "> ")
-                self.say("Mode " + self.status.flightmode)
+
+            if master.flightmode != self.status.last_mode_announced and time.time() > self.status.last_mode_announce + 2:
+                    self.status.last_mode_announce = time.time()
+                    self.status.last_mode_announced = master.flightmode
+                    self.say("Mode " + self.status.flightmode)
 
             if m.type == mavutil.mavlink.MAV_TYPE_FIXED_WING:
                 self.mpstate.vehicle_type = 'plane'


### PR DESCRIPTION
self.say(...) is still only called a maximum once/2 seconds

This should make the output from autotest clearer; currently several prompts appear with the old mode after a mode change