### PR TITLE
MAVCesium display as a submodule to MAVProxy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "MAVProxy/modules/mavproxy_cesium"]
+	path = MAVProxy/modules/mavproxy_cesium
+	url = https://github.com/SamuelDudley/MAVCesium.git

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-recursive-include MAVProxy/modules/mavproxy_cesium/app *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include MAVProxy/modules/mavproxy_cesium/app *

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,25 @@
 from setuptools import setup
+import os
 
 version = "1.5.1"
 
+def package_files(directory):
+    paths = []
+    for (path, directories, filenames) in os.walk(directory):
+        for filename in filenames:
+            paths.append(os.path.join('..', path, filename))
+    return paths
+
+package_data = ['modules/mavproxy_map/data/*.jpg', 
+                'modules/mavproxy_map/data/*.png',
+                'tools/graphs/*.xml',
+]
+
+package_data.extend(package_files('MAVProxy/modules/mavproxy_cesium/app'))
+
 setup(name='MAVProxy',
       version=version,
-      zip_safe=False,
-      include_package_data=True,
+      zip_safe=True,
       description='MAVProxy MAVLink ground station',
       long_description='''A MAVLink protocol proxy and ground station. MAVProxy
 is oriented towards command line operation, and is suitable for embedding in
@@ -51,7 +65,5 @@ on how to use MAVProxy.''',
                'MAVProxy/modules/mavproxy_map/mp_slipmap.py',
                'MAVProxy/modules/mavproxy_map/mp_tile.py'],
       package_data={'MAVProxy':
-                    ['modules/mavproxy_map/data/*.jpg', 
-                     'modules/mavproxy_map/data/*.png',
-                     'tools/graphs/*.xml']}
+                    package_data}
     )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ version = "1.5.1"
 
 setup(name='MAVProxy',
       version=version,
-      zip_safe=True,
+      zip_safe=False,
       description='MAVProxy MAVLink ground station',
       long_description='''A MAVLink protocol proxy and ground station. MAVProxy
 is oriented towards command line operation, and is suitable for embedding in
@@ -34,6 +34,7 @@ on how to use MAVProxy.''',
                 'MAVProxy.modules.mavproxy_map',
                 'MAVProxy.modules.mavproxy_misseditor',
                 'MAVProxy.modules.mavproxy_smartcamera',
+                'MAVProxy.modules.mavproxy_cesium',
                 'MAVProxy.modules.lib',
                 'MAVProxy.modules.lib.ANUGA',
                 'MAVProxy.modules.lib.optparse_gui'],
@@ -47,7 +48,7 @@ on how to use MAVProxy.''',
                'MAVProxy/tools/mavflightview.py',
                'MAVProxy/tools/MAVExplorer.py',
                'MAVProxy/modules/mavproxy_map/mp_slipmap.py',
-               'MAVProxy/modules/mavproxy_map/mp_tile.py'],
+               'MAVProxy/modules/mavproxy_map/mp_tile.py',],
       package_data={'MAVProxy':
                     ['modules/mavproxy_map/data/*.jpg', 
                      'modules/mavproxy_map/data/*.png',

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ version = "1.5.1"
 setup(name='MAVProxy',
       version=version,
       zip_safe=False,
+      include_package_data=True,
       description='MAVProxy MAVLink ground station',
       long_description='''A MAVLink protocol proxy and ground station. MAVProxy
 is oriented towards command line operation, and is suitable for embedding in
@@ -48,7 +49,7 @@ on how to use MAVProxy.''',
                'MAVProxy/tools/mavflightview.py',
                'MAVProxy/tools/MAVExplorer.py',
                'MAVProxy/modules/mavproxy_map/mp_slipmap.py',
-               'MAVProxy/modules/mavproxy_map/mp_tile.py',],
+               'MAVProxy/modules/mavproxy_map/mp_tile.py'],
       package_data={'MAVProxy':
                     ['modules/mavproxy_map/data/*.jpg', 
                      'modules/mavproxy_map/data/*.png',


### PR DESCRIPTION
Hi,
I have created a new map / HUD / synthetic FPV module for MAVProxy called [MAVCesium](https://github.com/SamuelDudley/MAVCesium). The module display runs in a webgl enabled browser and the module dependencies are pure python and _should_ be cross platform.

This pull request adds [MAVCesium](https://github.com/SamuelDudley/MAVCesium) as an optional submodule for MAVProxy.

I'm hoping to have [MAVCesium](https://github.com/SamuelDudley/MAVCesium) as part of the MAVProxy repo and this is the least intrusive way I could think about integrating it. I'm open to ideas and suggestions re other ideas.

Thanks,
Sam
