### PR TITLE
Logging: removed daemon hard-set directory of /var/log

### DIFF
--- a/MAVProxy/mavproxy.py
+++ b/MAVProxy/mavproxy.py
@@ -589,8 +589,6 @@ def log_paths():
     '''Returns tuple (logdir, telemetry_log_filepath, raw_telemetry_log_filepath)'''
     if opts.aircraft is not None:
         dirname = ""
-        if(opts.daemon):
-            dirname = '/var/log/'
         if opts.mission is not None:
             print(opts.mission)
             dirname += "%s/logs/%s/Mission%s" % (opts.aircraft, time.strftime("%Y-%m-%d"), opts.mission)
@@ -619,10 +617,7 @@ def log_paths():
         if not os.path.isabs(dir_path) and mpstate.settings.state_basedir is not None:
             dir_path = os.path.join(mpstate.settings.state_basedir,dir_path)
 
-        if(opts.daemon):
-            logdir = '/var/log'
-        else:
-            logdir = dir_path
+        logdir = dir_path
 
     mkdir_p(logdir)
     return (logdir,


### PR DESCRIPTION
Using /var/log as the daemon logfile directory required root. Removed this, so the user can decide where they want their logfiles stored.